### PR TITLE
disable paralleltest

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - paralleltest
+    # - paralleltest
     - revive
     - staticcheck
     - thelper


### PR DESCRIPTION
This isn't updated for `go1.22` loop concurrency yet - _idez started but hasn't released yet.

I like `go1.22` loop syntax more than I care about parallel tests.